### PR TITLE
Github workflow caching - .last_checked fix

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -50,15 +50,6 @@ jobs:
         run: |
           docker load -i docker-cache/images.tar
 
-      - name: Load last checked files list
-        id: load-last-checked
-        uses: actions/cache@v3
-        with:
-          path: .last_checked
-          key: last-checked-${{ hashFiles('.last_checked') }}
-          restore-keys: |
-            last-checked-
-
       - name: Set env for .venv in project
         run: echo "PIPENV_VENV_IN_PROJECT=1" >> $GITHUB_ENV
 
@@ -78,7 +69,7 @@ jobs:
 
       - name: Run check_project.sh
         run: |
-          ./dev-tools/check_project.sh --fast
+          ./dev-tools/check_project.sh
         env:
           PIPENV_VENV_IN_PROJECT: "True"
           DJANGO_SECRET_KEY: $(python3 -c 'from django.core.management.utils import get_random_secret_key; print(get_random_secret_key())')
@@ -105,10 +96,3 @@ jobs:
           images=$(grep 'image:' docker-compose.yml | awk '{ print $2 }')
           mkdir -p docker-cache
           docker save $images -o docker-cache/images.tar
-
-      - name: Save last checked files list
-        if: github.ref == 'refs/heads/main'
-        uses: actions/cache/save@v3
-        with:
-          path: .last_checked
-          key: last-checked-${{ hashFiles('.last_checked') }}


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


**What is the current behavior?** (You can also link to an open issue here)
The lint workflow might not always check all files.
Assume a timeline like this:
1. Feature A starts, file `x` is modified
2. Feature B starts, file `x` is modified
3. Feature B is merged into `main` (e.g. using a PR). The `.last_checked` file now contains the timestamp of `x` of feature B
4. Feature A is merged into `main` (e.g. using a PR). 

Now, `x` should be checked again as it is modified, but `x` will not be checked as the timestamp of `x` of feature A is older than the timestamp of `x` in feature B.


**What is the new behavior (if this is a feature change)? If possible add a screenshot.**
The fix is to just remove the caching of the file. As of my view, there is no sane way to deal with this (other than refreshing the timestamps once a feature is merged)


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


**Other information**:
The original issue was https://github.com/orgs/amosproj/projects/79/views/2?pane=issue&itemId=110335090&issue=amosproj%7Camos2025ss01-embark-orchestration-framework%7C33