### PR TITLE
Issue #33 fix 2 - Fix docker reference not found

### DIFF
--- a/.github/workflows/django-check.yml
+++ b/.github/workflows/django-check.yml
@@ -5,20 +5,14 @@ on: [push]
 jobs:
   django-integrity:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
 
     steps:
     - name: Checkout the Code
       uses: actions/checkout@v3
-    - name: Get Python 3.10
+    - name: Get Python
       uses: actions/setup-python@v3
       with:
-        python-version: "3.10"
-    - name: Case try other python
-      if: ${{ failure() }}
-      uses: actions/setup-python@v3
-      with:
-        python-version: "3.9"
+        python-version: 3.12
     - name: Install pipenv
       run: python -m pip install --upgrade pipenv
     - id: cache-pipenv
@@ -31,5 +25,3 @@ jobs:
       run: pipenv install --dev
     - name: Test Pipenv
       run: pipenv run test -svvv
-    # - name: Test Django 
-    #   run: pipenv run ./embark/manage.py check 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install dependencies for linting
         run: |
           sudo apt-get update -y
-          sudo apt-get install -y python3-dev npm pycodestyle bandit pylint
+          sudo apt-get install -y python3-dev npm pycodestyle bandit pylint yamllint shellcheck
           sudo npm install -g jshint
           sudo npm install -g @stoplight/spectral-cli
 
@@ -32,23 +32,6 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: 3.12
-
-      - name: Make directories
-        run: |
-          mkdir -p embark/logs embark/uploadFirmwareImages
-          touch embark/logs/web.log
-
-      - name: Restore cached Docker images
-        id: docker-cache-restore
-        uses: actions/cache@v3
-        with:
-          path: docker-cache/images.tar
-          key: embark-docker-images-${{ hashFiles('docker-compose.yml') }}
-
-      - name: Load Docker images from cache
-        if: steps.docker-cache-restore.outputs.cache-hit == 'true'
-        run: |
-          docker load -i docker-cache/images.tar
 
       - name: Set env for .venv in project
         run: echo "PIPENV_VENV_IN_PROJECT=1" >> $GITHUB_ENV
@@ -89,10 +72,3 @@ jobs:
           DJANGO_SUPERUSER_USERNAME:  "superuser"
           DJANGO_SUPERUSER_EMAIL:  "idk@lol.com"
 
-      - name: Save Docker images to cache
-        if: steps.docker-cache-restore.outputs.cache-hit != 'true'
-        # Requires docker-compose's "images: example:latest" to be on one line
-        run: |
-          images=$(grep 'image:' docker-compose.yml | awk '{ print $2 }')
-          mkdir -p docker-cache
-          docker save $images -o docker-cache/images.tar

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 - Additional worker information query ([Issue](https://github.com/orgs/amosproj/projects/79/views/2?pane=issue&itemId=111222216&issue=amosproj%7Camos2025ss01-embark-orchestration-framework%7C40))
 - Worker soft reset functionality ([Issue](https://github.com/orgs/amosproj/projects/79/views/2?pane=issue&itemId=112364355&issue=amosproj%7Camos2025ss01-embark-orchestration-framework%7C43))
 
+### FIXED
+
+- workflow caching (docker reference not found) ([Issue](https://github.com/orgs/amosproj/projects/79?pane=issue&itemId=110335090&issue=amosproj%7Camos2025ss01-embark-orchestration-framework%7C33))
+
 ## [sprint-07](https://github.com/amosproj/amos2025ss01-embark/releases/tag/sprint-07-release) - 2025-06-04
 
 ### ADDED


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


**What is the current behavior?** (You can also link to an open issue here)
If the `lint.yml` workflow is executed without cache keys, it fails as the installer script is not executed (and thus docker images are not pulled).

https://github.com/orgs/amosproj/projects/79?pane=issue&itemId=110335090&issue=amosproj%7Camos2025ss01-embark-orchestration-framework%7C33

**What is the new behavior (if this is a feature change)? If possible add a screenshot.**
As `check_project.sh` (which is executed by `lint.yml`) does not need docker, remove the docker caching. 

In addition, the python version of workflow `django-check.yml` is updated.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No