### PR TITLE
Bug fix for update_system_info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Fix a bug related to incorrect start of celery ([Issue](https://github.com/orgs/amosproj/projects/79/views/2?pane=issue&itemId=115359765&issue=amosproj%7Camos2025ss01-embark-orchestration-framework%7C79))
 - Fix a bug related to collecting worker dependency information
+- Fix a bug related to collecting worker external repo and emba version information
 
 ### ADDED
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


**What is the current behavior?** (You can also link to an open issue here)
Currently, the commands that fetch the worker system info related to the external repos may fail if the worker is unconfigured


**What is the new behavior (if this is a feature change)? If possible add a screenshot.**
Now, a more reliable check is performed to ensure that the external repos are downloaded on the worker


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No