### PR TITLE
Issue #43 1 - Add missing sudo to soft reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## UNRELEASED
 
+### FIXED
+
+- Fix missing sudo at worker soft reset ([Issue](https://github.com/orgs/amosproj/projects/79/views/2?pane=issue&itemId=112364355&issue=amosproj%7Camos2025ss01-embark-orchestration-framework%7C43))
+
 ## [sprint-10](https://github.com/amosproj/amos2025ss01-embark/releases/tag/sprint-10-release) - 2025-06-25
 
 ### FIXED

--- a/embark/workers/tasks.py
+++ b/embark/workers/tasks.py
@@ -293,7 +293,7 @@ def worker_soft_reset_task(worker_id, configuration_id):
     ssh_client = None
     try:
         ssh_client = worker.ssh_connect(configuration_id)
-        exec_blocking_ssh(ssh_client, "sudo docker ps -aq | xargs -r docker stop | xargs -r docker rm || true")
+        exec_blocking_ssh(ssh_client, "sudo docker ps -aq | xargs -r sudo docker stop | xargs -r sudo docker rm || true")
         exec_blocking_ssh(ssh_client, f"sudo rm -rf {settings.WORKER_EMBA_LOGS}")
         exec_blocking_ssh(ssh_client, f"sudo rm -rf {settings.WORKER_FIRMWARE_DIR}")
         ssh_client.close()


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


**What is the current behavior?** (You can also link to an open issue here)
Currently, a soft reset stops/deletes docker containers without sudo. This fails if the user is not root.


**What is the new behavior (if this is a feature change)? If possible add a screenshot.**
Now, a soft reset calls docker using sudo, thus this works if a different user than root is used.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No