### PR TITLE
Issue #70 2 - Missing WorkerDependencyVersion deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### FIXED
 
+- Missing WorkerDependencyVersion deletion on config delete
+
 ### ADDED
 
 - Worker health check and fetch analysis logs ([Issue](https://github.com/orgs/amosproj/projects/79/views/2?pane=issue&itemId=112364687&issue=amosproj%7Camos2025ss01-embark-orchestration-framework%7C46))

--- a/embark/workers/views.py
+++ b/embark/workers/views.py
@@ -83,7 +83,9 @@ def delete_config(request):
             undo_sudoers_file.delay(worker.ip_address, config.ssh_user, config.ssh_password)
 
         workers = Worker.objects.annotate(config_count=Count('configurations')).filter(configurations__id=selected_config_id, config_count=1)
-        workers.delete()
+        for worker in workers:
+            worker.dependency_version.delete()
+            worker.delete()
 
         config.delete()
         messages.success(request, 'Configuration deleted successfully')


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


**What is the current behavior?** (You can also link to an open issue here)
Currently, the created `WorkerDependencyVersion` object is not deleted if a worker is deleted caused by a configuration deletion


**What is the new behavior (if this is a feature change)? If possible add a screenshot.**
The related `WorkerDependencyVersion` object is deleted


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No
