### PR TITLE
Issue #94 - Indicate currently installed dependency versions for EMBA and externals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,11 @@
 
 - Worker health check and fetch analysis logs ([Issue](https://github.com/orgs/amosproj/projects/79/views/2?pane=issue&itemId=112364687&issue=amosproj%7Camos2025ss01-embark-orchestration-framework%7C46))
 - Abort running analysis on worker ([Issue](https://github.com/orgs/amosproj/projects/79/views/2?pane=issue&itemId=111365543&issue=amosproj%7Camos2025ss01-embark-orchestration-framework%7C41))
-- Trigger orchestrator at critical moments ([Issue](https://github.com/orgs/amosproj/projects/79/views/2?pane=issue&itemId=114047181&issue=amosproj%7Camos2025ss01-embark-orchestration-framework%7C59)) 
+- Trigger orchestrator at critical moments ([Issue](https://github.com/orgs/amosproj/projects/79/views/2?pane=issue&itemId=114047181&issue=amosproj%7Camos2025ss01-embark-orchestration-framework%7C59))
 - Use celery for IP range scanning and update config UI ([Issue](https://github.com/orgs/amosproj/projects/79/views/2?pane=issue&itemId=118038092&issue=amosproj%7Camos2025ss01-embark-orchestration-framework%7C91))
 - `process_update_queue` call once the analysis is finished ([Issue](https://github.com/orgs/amosproj/projects/79/views/2?pane=issue&itemId=114650622&issue=amosproj%7Camos2025ss01-embark-orchestration-framework%7C70))
 - Add wiki entries for API ([Issue](https://github.com/orgs/amosproj/projects/79/views/2?pane=issue&itemId=114744149&issue=amosproj%7Camos2025ss01-embark-orchestration-framework%7C71))
+- Indicate currently installed dependency versions ([Issue](https://github.com/orgs/amosproj/projects/79/views/2?pane=issue&itemId=118051293&issue=amosproj%7Camos2025ss01-embark-orchestration-framework%7C94))
 
 ## [sprint-11](https://github.com/amosproj/amos2025ss01-embark/releases/tag/sprint-11-release) - 2025-07-02
 

--- a/embark/templates/workers/overview.html
+++ b/embark/templates/workers/overview.html
@@ -142,17 +142,17 @@
                 <div class="actions-dropdown">
                     <button class="toggle-actions-menu" data-id="{{ worker.ip_address }}">...</button>
                     <div class="actions-dropdown-content" id="menu-{{ worker.ip_address }}">
-                            <button class="toggle-update-diff" dep-type="emba">Update EMBA
+                            <button class="toggle-update-diff" dep-type="emba" worker-id="{{ worker.id }}">Update EMBA
                             {% if worker.dependency_version.emba_outdated %}
                                 <span class="update-dot"/>
                             {% endif %}
                             </button>
-                            <button class="toggle-update-diff" dep-type="deb">Update APT dependencies
+                            <button class="toggle-update-diff" dep-type="deb" worker-id="{{ worker.id }}">Update APT dependencies
                             {% if worker.dependency_version.deb_outdated %}
                                 <span class="update-dot"/>
                             {% endif %}
                             </button>
-                            <button class="toggle-update-diff" dep-type="external">Update external directory
+                            <button class="toggle-update-diff" dep-type="external" worker-id="{{ worker.id }}">Update external directory
                             {% if worker.dependency_version.external_outdated %}
                                 <span class="update-dot"/>
                             {% endif %}
@@ -167,7 +167,7 @@
                         </form>
                     </div>
                 </div>
-                <div class="update-modal" id="update-modal-emba">
+                <div class="update-modal" id="update-modal-emba-{{ worker.id }}">
                     <div class="modal-content">
                         <div class="modal-title">
                             <p>Update diff - EMBA</p>
@@ -193,7 +193,7 @@
                         </div>
                     </div>
                 </div>
-                <div class="update-modal" id="update-modal-external">
+                <div class="update-modal" id="update-modal-external-{{ worker.id }}">
                     <div class="modal-content">
                         <div class="modal-title">
                             <p>Update diff - external directory</p>
@@ -227,7 +227,7 @@
                         </div>
                     </div>
                 </div>
-                <div class="update-modal" id="update-modal-deb">
+                <div class="update-modal" id="update-modal-deb-{{ worker.id }}">
                     <div class="modal-content">
                         <div class="modal-title">
                             <p>Update diff - APT dependencies</p>
@@ -340,7 +340,8 @@
     document.querySelectorAll(".toggle-update-diff").forEach(button => {
         button.addEventListener("click", function () {
             const type = button.getAttribute("dep-type");
-            const menu = document.getElementById("update-modal-" + type);
+            const workerId = button.getAttribute("worker-id");
+            const menu = document.getElementById("update-modal-" + type + "-" + workerId);
             if (menu) {
                 menu.style.display = (menu.style.display === "none" || menu.style.display === "") ? "block" : "none";
 

--- a/embark/templates/workers/overview.html
+++ b/embark/templates/workers/overview.html
@@ -142,21 +142,21 @@
                 <div class="actions-dropdown">
                     <button class="toggle-actions-menu" data-id="{{ worker.ip_address }}">...</button>
                     <div class="actions-dropdown-content" id="menu-{{ worker.ip_address }}">
-                        {% if worker.dependency_version.emba_outdated %}
                             <button class="toggle-update-diff" dep-type="emba">Update EMBA
+                            {% if worker.dependency_version.emba_outdated %}
                                 <span class="update-dot"/>
+                            {% endif %}
                             </button>
-                        {% endif %}
-                        {% if worker.dependency_version.deb_outdated %}
                             <button class="toggle-update-diff" dep-type="deb">Update APT dependencies
+                            {% if worker.dependency_version.deb_outdated %}
                                 <span class="update-dot"/>
+                            {% endif %}
                             </button>
-                        {% endif %}
-                        {% if worker.dependency_version.external_outdated %}
                             <button class="toggle-update-diff" dep-type="external">Update external directory
+                            {% if worker.dependency_version.external_outdated %}
                                 <span class="update-dot"/>
+                            {% endif %}
                             </button>
-                        {% endif %}
                         <form action="{% url 'embark-worker-hard-reset' worker.id %}" method="post">
                             {% csrf_token %}
                             <input type="submit" value="Hard Reset">
@@ -167,66 +167,74 @@
                         </form>
                     </div>
                 </div>
-                {% if worker.dependency_version.emba_outdated %}
-                    <div class="update-modal" id="update-modal-emba">
-                        <div class="modal-content">
-                            <div class="modal-title">
-                                <p>Update diff - EMBA</p>
-                                <div class="modal-close">×</div>
-                            </div>
-                            <div class="modal-body">
-                                <p><b>Installed:</b> EMBA {{ worker.dependency_version.emba }}</p>
-                                <p><b>Available:</b> EMBA {{ availableVersion.emba }}</p>
-                            </div>
-                            <div class="modal-action-buttons">
-                                <button class="modal-abort-button">Close</button>
-                                <form action="{% url 'embark-worker-update' worker.id %}" method="post">
-                                    {% csrf_token %}
-                                    <input type="hidden" name="update" value="emba">
-                                    <input type="submit" name="action" value="Update">
-                                </form>
-                            </div>
+                <div class="update-modal" id="update-modal-emba">
+                    <div class="modal-content">
+                        <div class="modal-title">
+                            <p>Update diff - EMBA</p>
+                            <div class="modal-close">×</div>
+                        </div>
+                        <div class="modal-body">
+                            <p><b>Installed:</b> EMBA {{ worker.dependency_version.emba }}</p>
+                            {% if worker.dependency_version.emba_outdated %}
+                            <p><b>Available:</b> EMBA {{ availableVersion.emba }}</p>
+                            {% else %}
+                            <br/><p>No update available.</p>
+                            {% endif %}
+                        </div>
+                        <div class="modal-action-buttons">
+                            <button class="modal-abort-button">Close</button>
+                            <form action="{% url 'embark-worker-update' worker.id %}" method="post">
+                                {% csrf_token %}
+                                <input type="hidden" name="update" value="emba">
+                                {% if worker.dependency_version.emba_outdated %}
+                                <input type="submit" name="action" value="Update">
+                                {% endif %}
+                            </form>
                         </div>
                     </div>
-                {% endif %}
-                {% if worker.dependency_version.external_outdated %}
-                    <div class="update-modal" id="update-modal-external">
-                        <div class="modal-content">
-                            <div class="modal-title">
-                                <p>Update diff - external directory</p>
-                                <div class="modal-close">×</div>
-                            </div>
-                            <div class="modal-body">
-                                <p><b>Installed:</b></p>
-                                <ul>
-                                    <li>NVD: {{ worker.dependency_version.nvd_head }} (Timestamp: {{ worker.dependency_version.nvd_time }})</li>
-                                    <li>EPSS: {{ worker.dependency_version.epss_head }} (Timestamp: {{ worker.dependency_version.epss_time }})</li>
-                                </ul>
-                                <p><b>Available:</b></p>
-                                <ul>
-                                    <li>NVD: {{ availableVersion.nvd_head }} (Timestamp: {{ availableVersion.nvd_time }})</li>
-                                    <li>EPSS: {{ availableVersion.epss_head }} (Timestamp: {{ availableVersion.epss_time }})</li>
-                                </ul>
-                            </div>
-                            <div class="modal-action-buttons">
-                                <button class="modal-abort-button">Close</button>
-                                <form action="{% url 'embark-worker-update' worker.id %}" method="post">
-                                    {% csrf_token %}
-                                    <input type="hidden" name="update" value="external">
-                                    <input type="submit" name="action" value="Update">
-                                </form>
-                            </div>
+                </div>
+                <div class="update-modal" id="update-modal-external">
+                    <div class="modal-content">
+                        <div class="modal-title">
+                            <p>Update diff - external directory</p>
+                            <div class="modal-close">×</div>
+                        </div>
+                        <div class="modal-body">
+                            <p><b>Installed:</b></p>
+                            <ul>
+                                <li>NVD: {{ worker.dependency_version.nvd_head }} (Timestamp: {{ worker.dependency_version.nvd_time }})</li>
+                                <li>EPSS: {{ worker.dependency_version.epss_head }} (Timestamp: {{ worker.dependency_version.epss_time }})</li>
+                            </ul>
+                            {% if worker.dependency_version.external_outdated %}
+                            <p><b>Available:</b></p>
+                            <ul>
+                                <li>NVD: {{ availableVersion.nvd_head }} (Timestamp: {{ availableVersion.nvd_time }})</li>
+                                <li>EPSS: {{ availableVersion.epss_head }} (Timestamp: {{ availableVersion.epss_time }})</li>
+                            </ul>
+                            {% else %}
+                            <br/><p>No update available.</p>
+                            {% endif %}
+                        </div>
+                        <div class="modal-action-buttons">
+                            <button class="modal-abort-button">Close</button>
+                            <form action="{% url 'embark-worker-update' worker.id %}" method="post">
+                                {% csrf_token %}
+                                <input type="hidden" name="update" value="external">
+                                {% if worker.dependency_version.external_outdated %}
+                                <input type="submit" name="action" value="Update">
+                                {% endif %}
+                            </form>
                         </div>
                     </div>
-                {% endif %}
-                {% if worker.dependency_version.deb_outdated %}
-                    <div class="update-modal" id="update-modal-deb">
-                        <div class="modal-content">
-                            <div class="modal-title">
-                                <p>Update diff - APT dependencies</p>
-                                <div class="modal-close">×</div>
-                            </div>
-                            <div class="modal-body">
+                </div>
+                <div class="update-modal" id="update-modal-deb">
+                    <div class="modal-content">
+                        <div class="modal-title">
+                            <p>Update diff - APT dependencies</p>
+                            <div class="modal-close">×</div>
+                        </div>
+                        <div class="modal-body">
+                            {% if worker.dependency_version.deb_outdated %}
                                 {% if worker.dependency_version.deb_list_diff.updated|length != 0 %}
                                     <p><b>Update available:</b></p>
                                     <ul>
@@ -251,18 +259,28 @@
                                     {% endfor %}
                                     </ul>
                                 {% endif %}
-                            </div>
-                            <div class="modal-action-buttons">
-                                <button class="modal-abort-button">Close</button>
-                                <form action="{% url 'embark-worker-update' worker.id %}" method="post">
-                                    {% csrf_token %}
-                                    <input type="hidden" name="update" value="deps">
-                                    <input type="submit" name="action" value="Update">
-                                </form>
-                            </div>
+                            {% else %}
+                                <p><b>Installed versions:</b></p>
+                                <ul>
+                                {% for deb_name, deb_info in worker.dependency_version.deb_list.items %}
+                                    <li>{{ deb_name }}: {{ deb_info.version }}</li>
+                                {% endfor %}
+                                </ul>
+                                <br/><p>No update available.</p>
+                            {% endif %}
+                        </div>
+                        <div class="modal-action-buttons">
+                            <button class="modal-abort-button">Close</button>
+                            <form action="{% url 'embark-worker-update' worker.id %}" method="post">
+                                {% csrf_token %}
+                                <input type="hidden" name="update" value="deps">
+                                {% if worker.dependency_version.deb_outdated %}
+                                <input type="submit" name="action" value="Update">
+                                {% endif %}
+                            </form>
                         </div>
                     </div>
-                {% endif %}
+                </div>
             {% endif %}
         </td>
     </tr>


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature


**What is the current behavior?** (You can also link to an open issue here)
Currently, the update buttons are only visible if an update is available.
https://github.com/orgs/amosproj/projects/79/views/2?pane=issue&itemId=118051293&issue=amosproj%7Camos2025ss01-embark-orchestration-framework%7C94

**What is the new behavior (if this is a feature change)? If possible add a screenshot.**
The update buttons are always visible, an available update is indicated using a red dot. If no update is available, it is shown in the modal. 


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


**Other information**:
I fixed a bug regarding non-unique ids of the modals.