### PR TITLE
Issue #70 - Add worker to orchestrator after update task

### DIFF
--- a/embark/workers/tasks.py
+++ b/embark/workers/tasks.py
@@ -321,12 +321,11 @@ def stop_remote_analysis(worker_id) -> None:
 
 
 @shared_task
-def update_worker(worker_id, add_orchestrator=True):
+def update_worker(worker_id):
     """
     Setup/Update an offline worker and add it to the orchestrator.
 
     :params worker_id: The worker to update
-    :params add_orchestrator: If True, re-adds worker to orchestrator
     """
     try:
         worker = Worker.objects.get(id=worker_id)
@@ -348,12 +347,9 @@ def update_worker(worker_id, add_orchestrator=True):
     if worker.status == Worker.ConfigStatus.CONFIGURED:
         try:
             update_system_info(worker)
-
-            if add_orchestrator:
-                orchestrator.add_worker(worker)
-                orchestrator.assign_tasks()
-                logger.info("Worker: %s added to orchestrator", worker.name)
-
+            orchestrator.add_worker(worker)
+            orchestrator.assign_tasks()
+            logger.info("Worker: %s added to orchestrator", worker.name)
         except ValueError:
             logger.error("Worker: %s already exists in orchestrator", worker.name)
 

--- a/embark/workers/update/update.py
+++ b/embark/workers/update/update.py
@@ -109,17 +109,15 @@ def queue_update(worker: Worker, dependency: DependencyType, version=None):
     if worker.status == Worker.ConfigStatus.CONFIGURING:
         return
 
-    removed = False
     try:
         orchestrator.remove_worker(worker)
-        removed = True
     except ValueError:
         pass
 
     worker.status = Worker.ConfigStatus.CONFIGURING
     worker.save()
 
-    update_worker.delay(worker.id, removed)
+    update_worker.delay(worker.id)
 
 
 def process_update_queue(worker: Worker):


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


**What is the current behavior?** (You can also link to an open issue here)
Currently, the worker is not added to the orchestrator after an update task, if the worker was not added prior to running the task.


**What is the new behavior (if this is a feature change)? If possible add a screenshot.**
The worker is always added to the orchestrator (if setup was successful) 


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No