### PR TITLE
Issue #104 - Hard reset routine in arbitrary execution order and incomplete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Deps setup error (APT sources are not updated)
 - Workers not consistently deleted ([Issue](https://github.com/orgs/amosproj/projects/79/views/2?pane=issue&itemId=119037519&issue=amosproj%7Camos2025ss01-embark-orchestration-framework%7C102))
+- Hard reset routine in arbitrary execution order and incomplete ([Issue](https://github.com/orgs/amosproj/projects/79/views/2?pane=issue&itemId=119117248&issue=amosproj%7Camos2025ss01-embark-orchestration-framework%7C104))
 
 ### ADDED
 

--- a/embark/workers/tasks.py
+++ b/embark/workers/tasks.py
@@ -459,6 +459,9 @@ def worker_soft_reset_task(worker_id):
 
 @shared_task
 def worker_hard_reset_task(worker_id):
+    orchestrator = get_orchestrator()
+    orchestrator.remove_worker(worker, False)
+
     try:
         worker = Worker.objects.get(id=worker_id)
     except Worker.DoesNotExist:
@@ -466,6 +469,9 @@ def worker_hard_reset_task(worker_id):
         return
     ssh_client = None
     try:
+        worker.status = Worker.ConfigStatus.UNCONFIGURED
+        worker.save()
+
         ssh_client = worker.ssh_connect()
         emba_path = os.path.join(settings.WORKER_EMBA_ROOT, "full_uninstaller.sh")
         exec_blocking_ssh(ssh_client, "sudo bash " + emba_path)

--- a/embark/workers/tasks.py
+++ b/embark/workers/tasks.py
@@ -462,6 +462,8 @@ def worker_hard_reset_task(worker_id):
     orchestrator = get_orchestrator()
     orchestrator.remove_worker(worker, False)
 
+    worker_soft_reset_task(worker_id)
+
     try:
         worker = Worker.objects.get(id=worker_id)
     except Worker.DoesNotExist:

--- a/embark/workers/tasks.py
+++ b/embark/workers/tasks.py
@@ -459,16 +459,17 @@ def worker_soft_reset_task(worker_id):
 
 @shared_task
 def worker_hard_reset_task(worker_id):
-    orchestrator = get_orchestrator()
-    orchestrator.remove_worker(worker, False)
-
-    worker_soft_reset_task(worker_id)
-
     try:
         worker = Worker.objects.get(id=worker_id)
     except Worker.DoesNotExist:
         logger.error("Worker Hard Reset: Invalid worker id")
         return
+
+    orchestrator = get_orchestrator()
+    orchestrator.remove_worker(worker, False)
+
+    worker_soft_reset_task(worker_id)
+
     ssh_client = None
     try:
         worker.status = Worker.ConfigStatus.UNCONFIGURED

--- a/embark/workers/views.py
+++ b/embark/workers/views.py
@@ -362,7 +362,6 @@ def worker_hard_reset(request, worker_id, configuration_id=None):
                 return safe_redirect(request, '/worker/')
 
         try:
-            worker_soft_reset_task.delay(worker.id)
             worker_hard_reset_task.delay(worker.id)
             messages.success(request, f'Worker hard reset queued: {worker.name}')
             return safe_redirect(request, '/worker/')

--- a/embark/workers/views.py
+++ b/embark/workers/views.py
@@ -326,7 +326,7 @@ def worker_soft_reset(request, worker_id, configuration_id=None):
 
         try:
             worker_soft_reset_task.delay(worker.id)
-            messages.success(request, f'Successfully soft resetted worker: ({worker.name})')
+            messages.success(request, f'Worker soft reset queued: {worker.name}')
             return safe_redirect(request, '/worker/')
         except BaseException:
             messages.error(request, 'Soft Reset failed.')
@@ -364,7 +364,7 @@ def worker_hard_reset(request, worker_id, configuration_id=None):
         try:
             worker_soft_reset_task.delay(worker.id)
             worker_hard_reset_task.delay(worker.id)
-            messages.success(request, f'Successfully hard resetted worker: ({worker.name})')
+            messages.success(request, f'Worker hard reset queued: {worker.name}')
             return safe_redirect(request, '/worker/')
         except BaseException:
             messages.error(request, 'Hard Reset failed.')


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


**What is the current behavior?** (You can also link to an open issue here)
Currently, a hard reset triggers both hard- and soft rests, but without enforcing an order.
In addition, during a hard reset, the worker is not removed from the worker / set to `UNCONFIGURED`.
https://github.com/orgs/amosproj/projects/79/views/2?pane=issue&itemId=119117248&issue=amosproj%7Camos2025ss01-embark-orchestration-framework%7C104

**What is the new behavior (if this is a feature change)? If possible add a screenshot.**
- An order is enforced (1. Soft reset, 2. Hard reset)
- Worker is set to status `UNCONFIGURED`
- Worker is removed from the orchestrator


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


**Other information**:
I removed unnecessary checks in the hard/soft reset functions in `workers/views.py`
