### PR TITLE
Issue-#107 - Show HEAD hash for worker EMBA version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
   - Dependency update script input sanitation
   - `queue_update` count optimization
 - SSH setup and sudo perm check ([Issue](https://github.com/orgs/amosproj/projects/79/views/2?pane=issue&itemId=119036293&issue=amosproj%7Camos2025ss01-embark-orchestration-framework%7C100))
+- Show HEAD hash for worker EMBA version ([Issue](https://github.com/orgs/amosproj/projects/79/views/2?pane=issue&itemId=119733872&issue=amosproj%7Camos2025ss01-embark-orchestration-framework%7C107))
 
 ## [sprint-12](https://github.com/amosproj/amos2025ss01-embark/releases/tag/sprint-12-release) - 2025-07-09
 

--- a/embark/templates/workers/overview.html
+++ b/embark/templates/workers/overview.html
@@ -174,11 +174,11 @@
                             <div class="modal-close">×</div>
                         </div>
                         <div class="modal-body">
-                            <p><b>Installed:</b> EMBA {{ worker.dependency_version.emba }}</p>
+                            <p><b>Installed:</b> EMBA {{ worker.dependency_version.emba }}: {{ worker.dependency_version.emba_head }}</p>
                             {% if worker.dependency_version.emba_outdated %}
-                            <p><b>Available:</b> EMBA {{ availableVersion.emba }}</p>
+                                <p><b>Available:</b> EMBA {{ availableVersion.emba }}: {{ availableVersion.emba_head }}</p>
                             {% else %}
-                            <br/><p>No update available.</p>
+                                <br/><p>No update available.</p>
                             {% endif %}
                         </div>
                         <div class="modal-action-buttons">

--- a/embark/templates/workers/overview.html
+++ b/embark/templates/workers/overview.html
@@ -134,29 +134,29 @@
         <td>{{ worker.system_info.cpu_info }}</td>
         <td>{{ worker.system_info.ram_info }}</td>
         <td>{{ worker.system_info.disk_info }}</td>
-        <td>{{ worker.dependency_version.emba }}</td>
-        <td>NVD: {{ worker.dependency_version.nvd_head|slice:"0:6" }}<br/>EPSS: {{ worker.dependency_version.epss_head|slice:"0:6" }}</td>
+        <td>{{ worker.dependency_version.emba }}: {{ worker.dependency_version.emba_head|slice:"0:7" }}</td>
+        <td>NVD: {{ worker.dependency_version.nvd_head|slice:"0:7" }}<br/>EPSS: {{ worker.dependency_version.epss_head|slice:"0:7" }}</td>
 
         <td>
             {% if worker.status != "Unconfigured" %}
                 <div class="actions-dropdown">
                     <button class="toggle-actions-menu" data-id="{{ worker.ip_address }}">...</button>
                     <div class="actions-dropdown-content" id="menu-{{ worker.ip_address }}">
-                            <button class="toggle-update-diff" dep-type="emba" worker-id="{{ worker.id }}">Update EMBA
+                        <button class="toggle-update-diff" dep-type="emba" worker-id="{{ worker.id }}">Update EMBA
                             {% if worker.dependency_version.emba_outdated %}
                                 <span class="update-dot"/>
                             {% endif %}
-                            </button>
-                            <button class="toggle-update-diff" dep-type="deb" worker-id="{{ worker.id }}">Update APT dependencies
+                        </button>
+                        <button class="toggle-update-diff" dep-type="deb" worker-id="{{ worker.id }}">Update APT dependencies
                             {% if worker.dependency_version.deb_outdated %}
                                 <span class="update-dot"/>
                             {% endif %}
-                            </button>
-                            <button class="toggle-update-diff" dep-type="external" worker-id="{{ worker.id }}">Update external directory
+                        </button>
+                        <button class="toggle-update-diff" dep-type="external" worker-id="{{ worker.id }}">Update external directory
                             {% if worker.dependency_version.external_outdated %}
                                 <span class="update-dot"/>
                             {% endif %}
-                            </button>
+                        </button>
                         <form action="{% url 'embark-worker-hard-reset' worker.id %}" method="post">
                             {% csrf_token %}
                             <input type="submit" value="Hard Reset">


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
---
Feature


**What is the current behavior?** (You can also link to an open issue here)
---
Only the EMBA version is shown in the menu

**What is the new behavior (if this is a feature change)? If possible add a screenshot.**
---
Now, the hash is also shown. The length for the head hash is seven chars.

Same goes for the external directory hashes to match git's default:

<img width="220" height="138" alt="image" src="https://github.com/user-attachments/assets/ea6a5d2c-e63d-4dac-b33e-7a18085517ee" />

Note: the second column is N/A because it hasn't been updated after the program changes were made.

The full hash is now shown in the "Update EMBA" menu:
<img width="462" height="115" alt="image" src="https://github.com/user-attachments/assets/1e432349-b831-420a-a89f-9397cc8f207b" />


Here though, the `Available: EMBA ...` line wouldn't be displayed during real use since there would be nothing to update. I just forced this to happen for testing purposes here since I updated all my VMs. Normally, and as in the current state of the program, it would look like this:
<img width="467" height="174" alt="image" src="https://github.com/user-attachments/assets/520eae84-b8aa-446c-ae8c-2ddc6cab5360" />


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
---
No


**Other information**:
---