### PR TITLE
fix two small bugs related to ssh key auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### FIXED
 
+- Broken config re-scan and ssh-copy-id bug 
+
+## [sprint-13](https://github.com/amosproj/amos2025ss01-embark/releases/tag/sprint-13-release) - 2025-07-16
+
+### FIXED
+
 - Deps setup error (APT sources are not updated)
 - Workers not consistently deleted ([Issue](https://github.com/orgs/amosproj/projects/79/views/2?pane=issue&itemId=119037519&issue=amosproj%7Camos2025ss01-embark-orchestration-framework%7C102))
 - Hard reset routine in arbitrary execution order and incomplete ([Issue](https://github.com/orgs/amosproj/projects/79/views/2?pane=issue&itemId=119117248&issue=amosproj%7Camos2025ss01-embark-orchestration-framework%7C104))

--- a/embark/workers/tasks.py
+++ b/embark/workers/tasks.py
@@ -724,15 +724,12 @@ def _update_or_create_worker(config: Configuration, ip_address: str):
         )
         worker.save()
         worker.configurations.set([config])
-        try:
-            init_sudoers_file(config, worker)
-            setup_ssh_key(config, worker)
-        except BaseException:
-            logger.error("Failed to setup SSH key or sudoers file for worker %s", worker.name)
-            worker.delete()
-            return
     finally:
         try:
+            # TODO: The first two function calls may cause issues when a config
+            #       is re-scanned after its first successful scan
+            init_sudoers_file(config, worker)
+            setup_ssh_key(config, worker)
             update_system_info(worker)
             update_dependencies_info(worker)
         except BaseException:


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


**What is the current behavior?** (You can also link to an open issue here)
Currently, ssh-copy-id may fail when the .ssh config directory has not been created in the users home directory.
Also, scanning a config that has been scanned before fails because ssh pw auth has been disabled and the config scan tries to execute a command on the worker using ssh pw auth


**What is the new behavior (if this is a feature change)? If possible add a screenshot.**
Now these two bugs have been fixed


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No